### PR TITLE
Depend on minor releases, don't use >=

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "coveralls": "jscoverage lib && LIVEFYRE_COV=1 nodeunit --reporter=lcov test/** | coveralls"
   },
   "dependencies": {
-    "validator": ">=3.5.0",
-    "restler": ">=3.2.0",
-    "jsonwebtoken": ">=5.0.0"
+    "validator": "^3.5.0",
+    "restler": "^3.2.0",
+    "jsonwebtoken": "^5.0.0"
   },
   "devDependencies": {
     "nodeunit": "~0.9.0",


### PR DESCRIPTION
Specifying '>=' as the comparator for
dependencies in package.json broke
downstream projects because *any* future
version of the dependencies can be used,
including versions with breaking changes.

depending on minor versions using `^` is safer.


> I noticed this problem because `livefyre` doesn't seem to be compatible with jsonwebtoken 8, even though npm and yarn both install jsonwebtoken 8 now, since the version is `>= 5`. I was getting `Error: expected object ` at jsonwebtoken/sign.js:35:11`. The cause is that jsonwebtoken is expecting to sign only POJOs, but `livefyre` is passing in something that isn't a POJO.