### PR TITLE
Don't allow jsonwebtoken to be updated beyond v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "validator": ">=3.5.0",
     "restler": ">=3.2.0",
-    "jsonwebtoken": ">=5.0.0"
+    "jsonwebtoken": "^7.4.3"
   },
   "devDependencies": {
     "nodeunit": "~0.9.0",


### PR DESCRIPTION
`jsonwebtoken` is currently being used on this line in `collections.js`
```
var token = jwt.sign(this.data, key, {noTimestamp: true});
```
where `this.data` refers to the object created in `Collection.init` with `new CollectionData(type, title, articleId, url)`.

In version 8, the `jwt.sign` function introduces a validation step on its first parameter using `lodash/isplainobject` ([docs](https://lodash.com/docs/4.17.4#isPlainObject)), which always fails for objects with a prototype, so it will fail on those created with the `new` keyword, therefore it will always fail in this project.

See [v7.4.3](https://github.com/auth0/node-jsonwebtoken/blob/v7.4.3/sign.js) versus [v8.0.0](https://github.com/auth0/node-jsonwebtoken/blob/v8.0.0/sign.js#L33)

Therefore this PR locks the `jsonwebtoken` version to minor versions of 7. 